### PR TITLE
Extract complete text for title

### DIFF
--- a/lib/Mojolicious/Plugin/PODViewer.pm
+++ b/lib/Mojolicious/Plugin/PODViewer.pm
@@ -229,7 +229,7 @@ sub _html {
 
   # Try to find a title
   my $title = 'Perldoc';
-  $dom->find('h1 + p')->first(sub { $title = shift->text });
+  $dom->find('h1 + p')->first(sub { $title = shift->all_text });
 
   # Combine everything to a proper response
   $c->content_for(perldoc => "$dom");

--- a/t/lib/MojoliciousTest/PODTest.pm
+++ b/t/lib/MojoliciousTest/PODTest.pm
@@ -4,7 +4,7 @@ package MojoliciousTest::PODTest;
 
 =head1 One
 
-PODTest
+L<MojoliciousTest::PODTest> - a test module
 
 =head2 Two
 


### PR DESCRIPTION
The module name in the page title is missing if it is included in a `L<ModuleName>`. Fixed using [all_text](https://mojolicious.org/perldoc/Mojo/DOM#all_text).