### PR TITLE
Fix breadcrumb link targets

### DIFF
--- a/lib/Mojolicious/Plugin/PODViewer.pm
+++ b/lib/Mojolicious/Plugin/PODViewer.pm
@@ -287,8 +287,8 @@ __DATA__
     % my $path;
     % for my $part (split '/', $module) {
         %= '::' if $path
-        % $path .= "/$part";
-        %= link_to $part => 'plugin.podviewer', { module => $module }
+        % $path .= $path ? "/$part" : $path;
+        %= link_to $part => 'plugin.podviewer', { module => $part }
     % }
     <span class="more">
         (<%= link_to 'source' => 'plugin.podviewer',


### PR DESCRIPTION
This fixes the breadcrumb links at the top of the page, where all links currently target the current module page, rather than the page for each of the ancestors.

EDIT: Clarify.. hopefully.